### PR TITLE
Feature/section detection

### DIFF
--- a/rag_service/src/ingestion/section_detect.py
+++ b/rag_service/src/ingestion/section_detect.py
@@ -26,7 +26,9 @@ EXCLUDED_SECTIONS = {
     "appendices",
 }
 
-BULLET_PATTERN = re.compile(r"^[-•\d]")
+# Matches bullet/list markers only — digits excluded so numbered headings
+# are handled by is_numbered_heading (Rule A) not rejected here
+BULLET_PATTERN = re.compile(r"^[-•]")
 NUMBERED_HEADING_PATTERN = re.compile(
     r"^(\d+(\.\d+)*\.?)\s+([A-Z][a-zA-Z0-9\s\-:()]{2,})$"
 )

--- a/rag_service/tests/ingestion/test_section_detect.py
+++ b/rag_service/tests/ingestion/test_section_detect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 from src.ingestion.section_detect import (
@@ -595,8 +596,8 @@ class TestAddSectionMetadata:
                 )
             ]
         )
-        result1 = add_section_metadata(doc)
-        result2 = add_section_metadata(doc)
+        result1 = add_section_metadata(copy.deepcopy(doc))
+        result2 = add_section_metadata(copy.deepcopy(doc))
         assert result1 == result2
 
     def test_empty_document(self) -> None:


### PR DESCRIPTION
# feat: Section Detection Pipeline - Issue #5 

## Summary
Implements the third step of the RAG ingestion pipeline — detecting headings and assigning hierarchical section metadata to all blocks, producing a `SectionedDocument` ready for chunking and citation.

---

## What's Included

### `src/ingestion/section_detect.py`
- `add_section_metadata(clean_doc)` — main entry point, returns a `SectionedDocument` dict
- `is_numbered_heading(text)` — detects numeric prefix headings (`1`, `2.1`, `3.2.1`)
- `is_allcaps_heading(text)` — detects all-caps headings (`INTRODUCTION`)
- `is_bold_heading(block)` — detects bold text headings
- `is_fontsize_heading(block, median)` — detects headings by font size relative to page median
- `is_excluded_section(section_title)` — identifies non-content sections for exclusion
- `_detect_heading(block, text, median)` — applies rules in priority order
- `_compute_page_median_font_size(blocks)` — computes per-page median font size

---

## New Block Fields

Every block in the output gains these fields:

| Field | Type | Description |
|---|---|---|
| `is_heading` | `bool` | True if block is a heading |
| `heading_level` | `int \| None` | 1, 2, or 3 (None for non-headings) |
| `section_path` | `list[str]` | e.g. `["Diagnosis", "Laboratory Tests"]` |
| `section_title` | `str` | Last element of section_path |
| `include_in_chunks` | `bool` | False for headings and excluded sections |

---

## Heading Detection Rules (Priority Order)

| Priority | Rule | Level |
|---|---|---|
| 1 | Numbered: `2.1 Monitoring` | dots + 1 |
| 2 | All-caps: `INTRODUCTION` | always 1 |
| 3 | Bold text ≤ 100 chars, < 15 words | always 2 |
| 4 | Font size ≥ page median + 2.0pt | 1 or 2 |

When multiple rules match, the highest priority rule wins.

---

## Section Path Algorithm

Maintains a stack while iterating blocks in reading order:
```
1 Diagnosis          → ["Diagnosis"]
  2.1 Tests          → ["Diagnosis", "Tests"]
  Test content       → ["Diagnosis", "Tests"]  (inherited)
  2.2 Imaging        → ["Diagnosis", "Imaging"]
2 Treatment          → ["Treatment"]
```

Numbered heading text is stripped of its numeric prefix:
`"2.1 Monitoring"` → `section_path = ["...", "Monitoring"]`

---

## Excluded Sections

Blocks in these sections get `include_in_chunks = False`:
- References, Bibliography, Citations
- Authors, Contributors, Affiliations
- Acknowledgments, Acknowledgements
- Disclosures, Conflicts of Interest
- Appendix, Appendices

Heading blocks also always get `include_in_chunks = False` — they provide structure not content.

---

## Key Technical Decisions

- **Rule priority is strict** — prevents conflicts when a block matches multiple rules (e.g. bold all-caps numbered heading always treated as numbered)
- **Per-page median font size** — font-size heading detection uses page-level median, not document-level, to handle documents with varying base font sizes across pages
- **Numbered prefix stripped from section_path** — `["Diagnosis", "Tests"]` not `["2", "2.1 Tests"]` for clean citations
- **Stack algorithm for nesting** — pops to correct depth before pushing new heading, handles level jumps gracefully
- **`heading_type` is an internal field** — used during processing then removed from final output to keep block structure clean

---

## Logging Output
```
Detected 12 numbered headings
Detected 3 all-caps headings
Detected 5 bold headings
Detected 2 font-size headings
Marked 18 blocks in excluded sections
```

---

## Tests — `tests/ingestion/test_section_detect.py`

100% coverage across all functions.

- `TestIsNumberedHeading` — level 1/2/3, trailing dot, dosage false positive, empty string
- `TestIsAllcapsHeading` — basic, multiword, too many words, too long, bullet prefix, mixed case, numbers, no alpha chars
- `TestIsBoldHeading` — bold detection, length, word count, bullet prefix, all-caps exclusion, empty text
- `TestIsFontsizeHeading` — level 1/2, body font, zero font, zero median, exact thresholds, below threshold
- `TestIsExcludedSection` — all excluded types, normal section, case insensitive
- `TestComputePageMedianFontSize` — basic median, zero exclusion, all zero, empty
- `TestDetectHeading` — all priority combinations verified
- `TestAddSectionMetadata` — full pipeline, nesting, inheritance, reset on new level, unknown fallback, excluded sections, all heading types, false positives, determinism, empty document

---

## Known Limitations

1. **Font-size detection** — simple median + threshold; may misclassify in documents with highly variable font sizes
2. **All-caps heuristic** — may detect lone acronyms as headings (e.g. `"RNA"` on its own line)
3. **Bold heading level** — all bold headings assigned level 2; cannot distinguish between bold heading levels without additional context
4. **Numbered heading variations** — handles `1.2.3` and `1.2.3.` only; doesn't handle Roman numerals or `(1)` format
5. **Section exclusion** — keyword matching only; may miss variations like `"List of References"`

---

## Acceptance Criteria

- [x] Numbered headings produce correctly nested section paths
- [x] All 4 heading types detected correctly
- [x] Rule priority respected — numbered wins over all others
- [x] Heading blocks: `is_heading = True`, `include_in_chunks = False`
- [x] Content blocks: `include_in_chunks = True` unless in excluded section
- [x] Reference/author sections: all blocks `include_in_chunks = False`
- [x] False positives avoided: `"2.5 mg dose"` not detected as heading
- [x] Deterministic — same input always produces same output
- [x] 100% test coverage

## Related Issues
Closes #5 