### PR TITLE
feat(frontend): add MVP help page and role-based workflow guidance

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,9 @@ const AdminRagPage = lazy(() => import('./pages/admin/AdminRagPage'));
 const ProfilePage = lazy(async () => ({
   default: (await import('./pages/ProfilePage')).ProfilePage,
 }));
+const HelpPage = lazy(async () => ({
+  default: (await import('./pages/HelpPage')).HelpPage,
+}));
 const NotFoundPage = lazy(async () => ({
   default: (await import('./pages/NotFoundPage')).NotFoundPage,
 }));
@@ -180,6 +183,14 @@ function App() {
                 element={
                   <ProtectedRoute allowedRoles={['gp', 'specialist', 'admin']}>
                     <ProfilePage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/help"
+                element={
+                  <ProtectedRoute allowedRoles={['gp', 'specialist']}>
+                    <HelpPage />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { User, LogOut, Shield } from 'lucide-react';
+import { User, LogOut, Shield, CircleHelp } from 'lucide-react';
 import { NHSLogo } from './NHSLogo';
 import { NotificationDropdown } from './NotificationDropdown';
 
@@ -16,6 +16,7 @@ export function Header({ userRole, userName, onLogout }: HeaderProps) {
 
   const isQueriesActive =
     location.pathname.includes('/queries') || location.pathname.includes('/query/');
+  const isHelpActive = location.pathname === '/help';
   const isAdminActive = location.pathname.startsWith('/admin');
 
   const handleLogout = () => {
@@ -46,6 +47,20 @@ export function Header({ userRole, userName, onLogout }: HeaderProps) {
                 }`}
               >
                 Queries
+              </Link>
+            )}
+
+            {userRole !== 'admin' && (
+              <Link
+                to="/help"
+                className={`text-white font-medium hover:text-white/80 transition-colors px-3 py-2 rounded ${
+                  isHelpActive ? 'bg-[var(--nhs-dark-blue)]' : ''
+                }`}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <CircleHelp className="w-4 h-4" />
+                  Help
+                </span>
               </Link>
             )}
 

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -22,7 +22,7 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
   gp: {
     workflowHeading: 'GP Workflow',
     summary:
-      'Use Ambience AI to structure your case, get an AI draft response, and track specialist review outcomes.',
+      'Use Ambience AI to create a case, get a draft answer, and follow specialist feedback.',
     steps: [
       {
         title: 'Step 1: Create the consultation',
@@ -35,7 +35,7 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
         title: 'Step 2: Review the consultation detail',
         bullets: [
           'Open the consultation detail page to review AI responses, citations, and conversation history.',
-          'Use follow-up messages to clarify missing context before clinical decision making.',
+          'Use follow-up messages to ask for missing details before making a decision.',
         ],
       },
       {
@@ -49,7 +49,7 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
         title: 'Step 4: Close out completed work',
         bullets: [
           'Archive completed consultations when they are no longer needed in your active list.',
-          'Retain important outcomes in your local record-keeping workflow as required.',
+          'Record important outcomes in your local notes as needed.',
         ],
       },
     ],
@@ -60,43 +60,43 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
       'Monitor notification updates when specialist actions occur.',
     ],
     limitations: [
-      'The AI output is decision support, not a final diagnosis or treatment directive.',
-      'Final clinical responsibility remains with the treating GP.',
-      'Avoid sharing unnecessary identifying patient information.',
-      'Escalate urgent or high-risk cases through established clinical safety processes.',
+      'AI responses are support only and are not a final diagnosis or treatment plan.',
+      'The GP remains responsible for final clinical decisions.',
+      'Do not add unnecessary identifying patient details.',
+      'Use your normal urgent-care process for high-risk cases.',
     ],
   },
   specialist: {
     workflowHeading: 'Specialist Workflow',
     summary:
-      'Use Ambience AI to triage assigned work, review AI output quality, and send clinically safe specialist decisions.',
+      'Use Ambience AI to review assigned cases, check draft quality, and send safe final advice.',
     steps: [
       {
-        title: 'Step 1: Triage incoming consultations',
+        title: 'Step 1: Check new consultations',
         bullets: [
-          'Open Queries for Review and monitor Queue and My Assigned tabs.',
-          'Sort by severity and status to prioritise urgent specialist work first.',
+          'Open Queries for Review and check Queue and My Assigned tabs.',
+          'Sort by urgency and status so urgent work is handled first.',
         ],
       },
       {
-        title: 'Step 2: Take ownership and assess evidence',
+        title: 'Step 2: Take the case and review details',
         bullets: [
-          'Assign a consultation when you are taking ownership of the review.',
-          'Inspect patient context, message history, and cited sources before deciding.',
+          'Assign the consultation when you are taking responsibility for review.',
+          'Read patient context, message history, and sources before deciding.',
         ],
       },
       {
-        title: 'Step 3: Complete specialist review actions',
+        title: 'Step 3: Choose a review action',
         bullets: [
-          'Use review actions to approve, request changes, or provide a manual response with supporting rationale.',
-          'Provide clear revision instructions when requesting changes from the model.',
+          'Use review actions to approve, request changes, or provide a manual response.',
+          'When requesting changes, write short and clear instructions.',
         ],
       },
       {
-        title: 'Step 4: Confirm resolution',
+        title: 'Step 4: Finish and update status',
         bullets: [
-          'Refresh and monitor statuses so no active consultations are left unresolved.',
-          'Use comments where needed so the GP receives clear next-step guidance.',
+          'Refresh and check statuses so no active consultations are left unresolved.',
+          'Add comments when needed so the GP gets clear next steps.',
         ],
       },
     ],
@@ -107,10 +107,10 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
       'Track pending workload with queue and assignment indicators.',
     ],
     limitations: [
-      'AI drafts can be incomplete and must be clinically validated before approval.',
-      'Specialist comments should be explicit when requesting revisions.',
-      'Do not rely on unsupported claims that lack source evidence.',
-      'Use existing trust escalation pathways for urgent safeguarding scenarios.',
+      'AI drafts can miss details, so always check them before approval.',
+      'Use clear comments so GPs understand what to do next.',
+      'Do not rely on claims that have no supporting source.',
+      'Use your normal emergency and safety process for urgent risks.',
     ],
   },
 };

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -5,10 +5,15 @@ import { orFallback } from '../utils/value';
 
 type HelpRole = 'gp' | 'specialist';
 
+interface HelpStep {
+  title: string;
+  bullets: string[];
+}
+
 interface HelpContent {
   workflowHeading: string;
   summary: string;
-  steps: string[];
+  steps: HelpStep[];
   features: string[];
   limitations: string[];
 }
@@ -19,11 +24,34 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
     summary:
       'Use Ambience AI to structure your case, get an AI draft response, and track specialist review outcomes.',
     steps: [
-      'Start in Queries and select New Consultation to create a case.',
-      'Enter patient context, specialty, urgency, and a clear clinical question before submitting.',
-      'Open the consultation detail page to review AI responses, citations, and conversation history.',
-      'Use consultation statuses (Submitted, Under Review, Closed) to follow progress through specialist review.',
-      'Archive completed consultations when they are no longer needed in your active list.',
+      {
+        title: 'Step 1: Create the consultation',
+        bullets: [
+          'Start in Queries and select New Consultation to create a case.',
+          'Enter patient context, specialty, urgency, and a clear clinical question before submitting.',
+        ],
+      },
+      {
+        title: 'Step 2: Review the consultation detail',
+        bullets: [
+          'Open the consultation detail page to review AI responses, citations, and conversation history.',
+          'Use follow-up messages to clarify missing context before clinical decision making.',
+        ],
+      },
+      {
+        title: 'Step 3: Track specialist review progress',
+        bullets: [
+          'Use consultation statuses (Submitted, Under Review, Closed) to follow progress through specialist review.',
+          'Check notifications when specialist actions occur on your consultation.',
+        ],
+      },
+      {
+        title: 'Step 4: Close out completed work',
+        bullets: [
+          'Archive completed consultations when they are no longer needed in your active list.',
+          'Retain important outcomes in your local record-keeping workflow as required.',
+        ],
+      },
     ],
     features: [
       'Search and filter consultations by text, specialty, and date.',
@@ -43,11 +71,34 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
     summary:
       'Use Ambience AI to triage assigned work, review AI output quality, and send clinically safe specialist decisions.',
     steps: [
-      'Open Queries for Review and monitor Queue and My Assigned tabs.',
-      'Assign a consultation when you are taking ownership of the review.',
-      'Inspect patient context, message history, and cited sources before deciding.',
-      'Use review actions to approve, request changes, or provide a manual response with supporting rationale.',
-      'Refresh and monitor statuses so no active consultations are left unresolved.',
+      {
+        title: 'Step 1: Triage incoming consultations',
+        bullets: [
+          'Open Queries for Review and monitor Queue and My Assigned tabs.',
+          'Sort by severity and status to prioritise urgent specialist work first.',
+        ],
+      },
+      {
+        title: 'Step 2: Take ownership and assess evidence',
+        bullets: [
+          'Assign a consultation when you are taking ownership of the review.',
+          'Inspect patient context, message history, and cited sources before deciding.',
+        ],
+      },
+      {
+        title: 'Step 3: Complete specialist review actions',
+        bullets: [
+          'Use review actions to approve, request changes, or provide a manual response with supporting rationale.',
+          'Provide clear revision instructions when requesting changes from the model.',
+        ],
+      },
+      {
+        title: 'Step 4: Confirm resolution',
+        bullets: [
+          'Refresh and monitor statuses so no active consultations are left unresolved.',
+          'Use comments where needed so the GP receives clear next-step guidance.',
+        ],
+      },
     ],
     features: [
       'Sort and filter by status, severity, specialty, and creation date.',
@@ -88,9 +139,16 @@ export function HelpPage() {
             <Info className="w-5 h-5 text-[var(--nhs-blue)]" />
             {content.workflowHeading}
           </h2>
-          <ol className="mt-4 space-y-3 text-gray-800 list-decimal list-inside">
+          <ol className="mt-4 space-y-4 text-gray-800 list-decimal list-inside">
             {content.steps.map((step) => (
-              <li key={step}>{step}</li>
+              <li key={step.title} className="bg-slate-50 border border-slate-200 rounded-lg p-4">
+                <h3 className="font-semibold text-gray-900">{step.title}</h3>
+                <ul className="mt-2 space-y-2 text-gray-800 list-disc list-inside">
+                  {step.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              </li>
             ))}
           </ol>
         </section>

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -1,0 +1,124 @@
+import { CheckCircle2, Info, TriangleAlert } from 'lucide-react';
+import { Header } from '../components/Header';
+import { useAuth } from '../contexts/useAuth';
+import { orFallback } from '../utils/value';
+
+type HelpRole = 'gp' | 'specialist';
+
+interface HelpContent {
+  workflowHeading: string;
+  summary: string;
+  steps: string[];
+  features: string[];
+  limitations: string[];
+}
+
+const HELP_CONTENT: Record<HelpRole, HelpContent> = {
+  gp: {
+    workflowHeading: 'GP Workflow',
+    summary:
+      'Use Ambience AI to structure your case, get an AI draft response, and track specialist review outcomes.',
+    steps: [
+      'Start in Queries and select New Consultation to create a case.',
+      'Enter patient context, specialty, urgency, and a clear clinical question before submitting.',
+      'Open the consultation detail page to review AI responses, citations, and conversation history.',
+      'Use consultation statuses (Submitted, Under Review, Closed) to follow progress through specialist review.',
+      'Archive completed consultations when they are no longer needed in your active list.',
+    ],
+    features: [
+      'Search and filter consultations by text, specialty, and date.',
+      'Update consultation metadata when details change.',
+      'Attach supporting files to provide extra context for the model.',
+      'Monitor notification updates when specialist actions occur.',
+    ],
+    limitations: [
+      'The AI output is decision support, not a final diagnosis or treatment directive.',
+      'Final clinical responsibility remains with the treating GP.',
+      'Avoid sharing unnecessary identifying patient information.',
+      'Escalate urgent or high-risk cases through established clinical safety processes.',
+    ],
+  },
+  specialist: {
+    workflowHeading: 'Specialist Workflow',
+    summary:
+      'Use Ambience AI to triage assigned work, review AI output quality, and send clinically safe specialist decisions.',
+    steps: [
+      'Open Queries for Review and monitor Queue and My Assigned tabs.',
+      'Assign a consultation when you are taking ownership of the review.',
+      'Inspect patient context, message history, and cited sources before deciding.',
+      'Use review actions to approve, request changes, or provide a manual response with supporting rationale.',
+      'Refresh and monitor statuses so no active consultations are left unresolved.',
+    ],
+    features: [
+      'Sort and filter by status, severity, specialty, and creation date.',
+      'Review consultation and message-level controls from the specialist detail page.',
+      'Attach additional files and source references when manual responses are needed.',
+      'Track pending workload with queue and assignment indicators.',
+    ],
+    limitations: [
+      'AI drafts can be incomplete and must be clinically validated before approval.',
+      'Specialist comments should be explicit when requesting revisions.',
+      'Do not rely on unsupported claims that lack source evidence.',
+      'Use existing trust escalation pathways for urgent safeguarding scenarios.',
+    ],
+  },
+};
+
+function resolveHelpRole(role: string | null): HelpRole {
+  return role === 'specialist' ? 'specialist' : 'gp';
+}
+
+export function HelpPage() {
+  const { role, username, logout } = useAuth();
+  const helpRole = resolveHelpRole(role);
+  const content = HELP_CONTENT[helpRole];
+
+  return (
+    <div className="min-h-screen bg-[var(--nhs-page-bg)] flex flex-col">
+      <Header userRole={helpRole} userName={orFallback(username, 'User')} onLogout={logout} />
+
+      <main className="flex-1 max-w-6xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <section className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 sm:p-8">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Help & Usage Guide</h1>
+          <p className="mt-2 text-gray-700">{content.summary}</p>
+        </section>
+
+        <section className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 sm:p-8">
+          <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 inline-flex items-center gap-2">
+            <Info className="w-5 h-5 text-[var(--nhs-blue)]" />
+            {content.workflowHeading}
+          </h2>
+          <ol className="mt-4 space-y-3 text-gray-800 list-decimal list-inside">
+            {content.steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 sm:p-8">
+          <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 inline-flex items-center gap-2">
+            <CheckCircle2 className="w-5 h-5 text-green-700" />
+            Key Features
+          </h2>
+          <ul className="mt-4 space-y-2 text-gray-800 list-disc list-inside">
+            {content.features.map((feature) => (
+              <li key={feature}>{feature}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="bg-amber-50 rounded-xl shadow-sm border border-amber-200 p-6 sm:p-8">
+          <h2 className="text-xl sm:text-2xl font-semibold text-amber-900 inline-flex items-center gap-2">
+            <TriangleAlert className="w-5 h-5 text-amber-700" />
+            Safety And Limitations
+          </h2>
+          <ul className="mt-4 space-y-2 text-amber-900 list-disc list-inside">
+            {content.limitations.map((limitation) => (
+              <li key={limitation}>{limitation}</li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -75,13 +75,16 @@ const HELP_CONTENT: Record<HelpRole, HelpContent> = {
         title: 'Step 1: Check new consultations',
         bullets: [
           'Open Queries for Review and check Queue and My Assigned tabs.',
+          'The Queue tab shows queries that are available to assign to yourself.',
+          'The My Assigned tab shows queries you already own.',
           'Sort by urgency and status so urgent work is handled first.',
         ],
       },
       {
         title: 'Step 2: Take the case and review details',
         bullets: [
-          'Assign the consultation when you are taking responsibility for review.',
+          'Open a query from Queue and press Assign to Me to take ownership.',
+          'You must assign the query to yourself before you can respond to it.',
           'Read patient context, message history, and sources before deciding.',
         ],
       },

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -87,6 +87,7 @@ describe('App', () => {
       ['/gp/queries', /my consultations/i],
       ['/gp/queries/new', /new consultation/i],
       ['/gp/query/1', /headache consultation/i],
+      ['/help', /gp workflow/i],
     ] as const;
 
     for (const [route, text] of cases) {
@@ -107,6 +108,7 @@ describe('App', () => {
     const cases = [
       ['/specialist/queries', /queries for review/i],
       ['/specialist/query/1', /headache consultation/i],
+      ['/help', /specialist workflow/i],
     ] as const;
 
     for (const [route, text] of cases) {
@@ -146,4 +148,17 @@ describe('App', () => {
       unmount();
     }
   }, 30000);
+
+  it('blocks admins from the gp and specialist help route', async () => {
+    seedAuth({ role: 'admin', username: 'Admin User' });
+    window.history.pushState({}, '', '/help');
+    render(<App />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/access restricted/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
 });

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -55,6 +55,28 @@ describe('Header', () => {
     expect(screen.getByText('Queries')).toBeInTheDocument();
   });
 
+  it('shows Help link for GP role', () => {
+    renderHeader({ userRole: 'gp' });
+    expect(screen.getByRole('link', { name: /help/i })).toBeInTheDocument();
+  });
+
+  it('shows Help link for specialist role', () => {
+    renderHeader({ userRole: 'specialist' }, '/specialist/queries');
+    expect(screen.getByRole('link', { name: /help/i })).toBeInTheDocument();
+  });
+
+  it('does not show Help link for admin role', () => {
+    renderHeader({ userRole: 'admin' }, '/admin/users');
+    expect(screen.queryByRole('link', { name: /help/i })).not.toBeInTheDocument();
+  });
+
+  it('marks Help link active on the help route', () => {
+    renderHeader({ userRole: 'gp' }, '/help');
+    expect(screen.getByRole('link', { name: /help/i }).className).toContain(
+      'bg-[var(--nhs-dark-blue)]',
+    );
+  });
+
   it('shows Admin Panel link for admin role', () => {
     renderHeader({ userRole: 'admin' }, '/admin/users');
     expect(screen.getByText('Admin Panel')).toBeInTheDocument();

--- a/frontend/tests/integration/app_flows.test.tsx
+++ b/frontend/tests/integration/app_flows.test.tsx
@@ -22,6 +22,25 @@ describe('app integration flows', () => {
     });
   });
 
+  it('gp can open the help page from the header', async () => {
+    seedAuth({ role: 'gp', username: 'Dr GP', email: 'gp@example.com' });
+    window.history.pushState({}, '', '/gp/queries');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /my consultations/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: /help/i }));
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/help');
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /gp workflow/i })).toBeInTheDocument();
+    });
+  });
+
   it('gp chat detail shows messages and citations', async () => {
     seedAuth({ role: 'gp', username: 'Dr GP', email: 'gp@example.com' });
     server.use(
@@ -127,6 +146,25 @@ describe('app integration flows', () => {
     expect(screen.getByText(/queue \(/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /my assigned/i }));
     expect(screen.getByText(/my assigned/i)).toBeInTheDocument();
+  });
+
+  it('specialist can open the help page from the header', async () => {
+    seedAuth({ role: 'specialist', username: 'Dr Specialist', email: 'specialist@example.com' });
+    window.history.pushState({}, '', '/specialist/queries');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /queries for review/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: /help/i }));
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/help');
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /specialist workflow/i })).toBeInTheDocument();
+    });
   });
 
   it('specialist chat detail shows review controls', async () => {

--- a/frontend/tests/pages/HelpPage.test.tsx
+++ b/frontend/tests/pages/HelpPage.test.tsx
@@ -38,7 +38,7 @@ describe('HelpPage', () => {
       screen.getByText(/enter patient context, specialty, urgency, and a clear clinical question/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/final clinical responsibility remains with the treating gp/i),
+      screen.getByText(/the gp remains responsible for final clinical decisions/i),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /help/i }).className).toContain(
       'bg-[var(--nhs-dark-blue)]',
@@ -52,12 +52,12 @@ describe('HelpPage', () => {
       expect(screen.getByRole('heading', { name: /specialist workflow/i })).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/step 1: triage incoming consultations/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 1: check new consultations/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/assign a consultation when you are taking ownership of the review/i),
+      screen.getByText(/assign the consultation when you are taking responsibility for review/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/queue and my assigned tabs/i)).toBeInTheDocument();
-    expect(screen.getByText(/ai drafts can be incomplete/i)).toBeInTheDocument();
+    expect(screen.getByText(/ai drafts can miss details/i)).toBeInTheDocument();
   });
 
   it('shows shared page sections for features and limitations', async () => {

--- a/frontend/tests/pages/HelpPage.test.tsx
+++ b/frontend/tests/pages/HelpPage.test.tsx
@@ -54,7 +54,13 @@ describe('HelpPage', () => {
 
     expect(screen.getByText(/step 1: check new consultations/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/assign the consultation when you are taking responsibility for review/i),
+      screen.getByText(/queue tab shows queries that are available to assign to yourself/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/open a query from queue and press assign to me to take ownership/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/you must assign the query to yourself before you can respond to it/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/queue and my assigned tabs/i)).toBeInTheDocument();
     expect(screen.getByText(/ai drafts can miss details/i)).toBeInTheDocument();

--- a/frontend/tests/pages/HelpPage.test.tsx
+++ b/frontend/tests/pages/HelpPage.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { HelpPage } from '@/pages/HelpPage';
+import { renderWithProviders, seedAuth } from '@test/utils';
+
+function renderHelpPage(role: 'gp' | 'specialist') {
+  seedAuth({
+    role,
+    username: role === 'gp' ? 'Dr GP' : 'Dr Specialist',
+    email: role === 'gp' ? 'gp@example.com' : 'specialist@example.com',
+  });
+
+  return renderWithProviders(
+    <Routes>
+      <Route path="/help" element={<HelpPage />} />
+      <Route path="/gp/queries" element={<div>GP Queries</div>} />
+      <Route path="/specialist/queries" element={<div>Specialist Queries</div>} />
+      <Route path="/profile" element={<div>Profile</div>} />
+      <Route path="/login" element={<div>Login</div>} />
+    </Routes>,
+    { routes: ['/help'] },
+  );
+}
+
+describe('HelpPage', () => {
+  it('renders GP workflow guidance and safety limitations', async () => {
+    renderHelpPage('gp');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /help & usage guide/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', { name: /gp workflow/i })).toBeInTheDocument();
+    expect(screen.getByText(/start in queries and select new consultation/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/final clinical responsibility remains with the treating gp/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /help/i }).className).toContain(
+      'bg-[var(--nhs-dark-blue)]',
+    );
+  });
+
+  it('renders specialist workflow guidance and feature list', async () => {
+    renderHelpPage('specialist');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /specialist workflow/i })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/assign a consultation when you are taking ownership of the review/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/queue and my assigned tabs/i)).toBeInTheDocument();
+    expect(screen.getByText(/ai drafts can be incomplete/i)).toBeInTheDocument();
+  });
+
+  it('shows shared page sections for features and limitations', async () => {
+    renderHelpPage('gp');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /key features/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', { name: /safety and limitations/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/HelpPage.test.tsx
+++ b/frontend/tests/pages/HelpPage.test.tsx
@@ -32,7 +32,11 @@ describe('HelpPage', () => {
     });
 
     expect(screen.getByRole('heading', { name: /gp workflow/i })).toBeInTheDocument();
+    expect(screen.getByText(/step 1: create the consultation/i)).toBeInTheDocument();
     expect(screen.getByText(/start in queries and select new consultation/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/enter patient context, specialty, urgency, and a clear clinical question/i),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/final clinical responsibility remains with the treating gp/i),
     ).toBeInTheDocument();
@@ -48,6 +52,7 @@ describe('HelpPage', () => {
       expect(screen.getByRole('heading', { name: /specialist workflow/i })).toBeInTheDocument();
     });
 
+    expect(screen.getByText(/step 1: triage incoming consultations/i)).toBeInTheDocument();
     expect(
       screen.getByText(/assign a consultation when you are taking ownership of the review/i),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add a new `/help` page with simple, role-based guidance for GP and specialist users
- add a Help button in the header for GP and specialist roles
- protect `/help` so only GP/specialist accounts can access it
- add step-by-step workflow instructions with bullet points for each step
- clarify specialist ownership flow: assignable queries are in **Queue**, and users must open a query and click **Assign to Me** before responding

## Tests
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
